### PR TITLE
fix: メンバー一覧のスクロールアニメーションがスマホで崩れる問題を修正

### DIFF
--- a/src/components/sections/member/MemberListSection.tsx
+++ b/src/components/sections/member/MemberListSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from "next/image"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { gsap } from "gsap"
 import { ScrollTrigger } from "gsap/ScrollTrigger"
 import TypingText from "@/components/ui/TypingText"
@@ -30,37 +30,41 @@ function shuffle<T>(arr: readonly T[]): T[] {
 
 export default function MemberListSection({ members }: MemberListSectionProps) {
   const [ordered, setOrdered] = useState<MemberListItem[]>(members)
+  const listRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     setOrdered(shuffle(members))
   }, [members])
 
   useEffect(() => {
-    const cards = document.querySelectorAll('.member-card')
+    if (!listRef.current) return
 
-    cards.forEach((card) => {
-      const image = card.querySelector('.member-image')
-      const content = card.querySelector('.member-content')
+    const ctx = gsap.context(() => {
+      const cards = gsap.utils.toArray<HTMLElement>('.member-card')
 
-      gsap.set(image, { opacity: 0, x: -20 })
-      gsap.set(content, { opacity: 0, y: 20 })
+      cards.forEach((card) => {
+        const images = card.querySelectorAll<HTMLElement>('.member-image')
+        const contents = card.querySelectorAll<HTMLElement>('.member-content')
 
-      const tl = gsap.timeline({
-        scrollTrigger: {
-          trigger: card,
-          start: "top 80%",
-          toggleActions: "play none none reverse"
-        }
+        gsap.set(images, { opacity: 0, x: -20 })
+        gsap.set(contents, { opacity: 0, y: 20 })
+
+        gsap.timeline({
+          scrollTrigger: {
+            trigger: card,
+            start: "top 85%",
+            toggleActions: "play none none none",
+          },
+        })
+          .to(images, { opacity: 1, x: 0, duration: 0.6, ease: "power2.out" })
+          .to(contents, { opacity: 1, y: 0, duration: 0.5, ease: "power2.out" }, "-=0.3")
       })
+    }, listRef)
 
-      tl.to(image, { opacity: 1, x: 0, duration: 0.6, ease: "power2.out" })
-        .to(content, { opacity: 1, y: 0, duration: 0.5, ease: "power2.out" }, "-=0.3")
-    })
+    ScrollTrigger.refresh()
 
-    return () => {
-      ScrollTrigger.getAll().forEach(trigger => trigger.kill())
-    }
-  }, [])
+    return () => ctx.revert()
+  }, [ordered])
 
   return (
     <section className="bg-white pt-20 md:pt-40 pb-16 md:pb-24">
@@ -116,7 +120,7 @@ export default function MemberListSection({ members }: MemberListSectionProps) {
           {/* 右10col: 2列グリッド(5+5) */}
           <div className="lg:col-span-10">
             {/* Mobile: 1列 / Desktop: 2列 */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-0">
+            <div ref={listRef} className="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-0">
               {ordered.map(({ member, preview }) => (
                 <TransitionLink
                   key={member.id}


### PR DESCRIPTION
## やったこと

メンバー一覧ページで、スマホ表示時にカードが「白く抜けて表示されない」「特定のカードだけ見える」「スクロールで戻ると消える」といった現象が起きていたのを根本修正。

`MemberListSection.tsx` に潜んでいた以下4つの構造問題を一括で解消：

1. **GSAP の ScrollTrigger が shuffle 前の DOM 位置に紐づいていた**
   - `useEffect` 依存配列を `[]` → `[ordered]` に変更し、shuffle 後の正しい順序で再セットアップ
2. **`querySelector` が Mobile/Desktop 二重マークアップの片方しか掴んでいなかった**
   - `querySelectorAll` に変更し、両方の `.member-image` / `.member-content` に `opacity` を適用
3. **`toggleActions: "play none none reverse"` でスクロールバック時にカードが消えていた**
   - `"play none none none"` に変更し、一度出たカードは保持
4. **`document.querySelectorAll` + `ScrollTrigger.getAll().kill()` でページ全体に影響していた**
   - `gsap.context(fn, listRef)` でスコープを自セクション内に限定し、cleanup も `ctx.revert()` で安全化
   - レイアウト確定後の `ScrollTrigger.refresh()` も追加

## 影響範囲

- `src/components/sections/member/MemberListSection.tsx` のみ
- `/member` 一覧ページのスクロール演出
- 他ページの GSAP 演出には影響しない（scope を `listRef` に閉じたため、むしろ副作用が減る方向）

## 備考

- スマホ実機 / Chrome DevTools のデバイスモードでリロードを数回行い、shuffle 後も全カードが順次フェードインすること、スクロールバックで消えないことの確認推奨

## チェックリスト
- [x] 自身のコードをセルフレビューしましたか？
- [x] コーディング規約/フォーマッターに従っていますか？
- [x] 不要な \`console.log\` やデバッグコードを削除しましたか？