### PR TITLE
feat: お問い合わせ・求人応募フォームに「知ったきっかけ」選択項目を追加

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -15,6 +15,7 @@ async function sendSlackNotification(data: {
   company: string
   subject: string
   email: string
+  source: string
   message: string
   notionPageUrl: string
   notionPageId: string
@@ -71,7 +72,7 @@ async function sendSlackNotification(data: {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `*氏名:* ${data.name}\n\n*会社名:* ${data.company || '未記入'}\n\n*メールアドレス:* ${data.email}\n\n*受信日時:* ${timestamp}`
+          text: `*氏名:* ${data.name}\n\n*会社名:* ${data.company || '未記入'}\n\n*メールアドレス:* ${data.email}\n\n*知ったきっかけ:* ${data.source || '未選択'}\n\n*受信日時:* ${timestamp}`
         }
       },
       {
@@ -134,9 +135,9 @@ async function sendSlackNotification(data: {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { name, company, subject, email, message } = body
+    const { name, company, subject, email, source, message } = body
 
-    console.log('Received data:', { name, company, subject, email, message })
+    console.log('Received data:', { name, company, subject, email, source, message })
 
     // バリデーション
     if (!name || !email || !message) {
@@ -193,6 +194,15 @@ export async function POST(request: NextRequest) {
             },
           ],
         },
+        source: {
+          rich_text: [
+            {
+              text: {
+                content: source || '',
+              },
+            },
+          ],
+        },
         message: {
           rich_text: [
             {
@@ -216,6 +226,7 @@ export async function POST(request: NextRequest) {
       company,
       subject,
       email,
+      source,
       message,
       notionPageUrl,
       notionPageId: notionResponse.id

--- a/src/app/api/recruit/route.ts
+++ b/src/app/api/recruit/route.ts
@@ -10,9 +10,9 @@ const dataSourceId = process.env.NOTION_RECRUIT_DATA_SOURCE_ID
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { name, email, phone, position, portfolio, message } = body
+    const { name, email, phone, position, portfolio, source, message } = body
 
-    console.log('Received recruit data:', { name, email, phone, position, portfolio, message })
+    console.log('Received recruit data:', { name, email, phone, position, portfolio, source, message })
 
     // バリデーション
     if (!name || !email || !phone || !position || !message) {
@@ -65,6 +65,15 @@ export async function POST(request: NextRequest) {
         },
         portfolio: {
           url: portfolio || null,
+        },
+        source: {
+          rich_text: [
+            {
+              text: {
+                content: source || '',
+              },
+            },
+          ],
         },
         message: {
           rich_text: [

--- a/src/components/sections/common/ContactSection.tsx
+++ b/src/components/sections/common/ContactSection.tsx
@@ -4,6 +4,7 @@ import { gsap } from 'gsap'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
 import { companySNS } from '@/data/company'
 import Select from '@/components/ui/Select'
+import { sourceOptions } from '@/data/sourceOptions'
 import toast from 'react-hot-toast'
 
 gsap.registerPlugin(ScrollTrigger)
@@ -14,6 +15,7 @@ export default function ContactSection() {
     company: '',
     subject: '',
     email: '',
+    source: '',
     message: ''
   })
 
@@ -70,6 +72,7 @@ export default function ContactSection() {
           company: '',
           subject: '',
           email: '',
+          source: '',
           message: '',
         })
       } else {
@@ -278,6 +281,20 @@ export default function ContactSection() {
                     className="w-full border-0 border-b border-gray-300 bg-transparent py-3 text-gray-900 placeholder-gray-400 focus:border-gray-600 focus:outline-none focus:ring-0"
                   />
                 </div>
+              </div>
+
+              {/* Source */}
+              <div>
+                <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                  当社を知ったきっかけ
+                </label>
+                <Select
+                  name="source"
+                  value={formData.source}
+                  onChange={(value) => handleSelectChange('source', value)}
+                  options={sourceOptions}
+                  placeholder="選択してください"
+                />
               </div>
 
               {/* Message */}

--- a/src/components/sections/recruit/apply/RecruitApplyFormSection.tsx
+++ b/src/components/sections/recruit/apply/RecruitApplyFormSection.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 import { gsap } from 'gsap'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
 import Select from '@/components/ui/Select'
+import { sourceOptions } from '@/data/sourceOptions'
 import toast from 'react-hot-toast'
 
 gsap.registerPlugin(ScrollTrigger)
@@ -15,6 +16,7 @@ export default function RecruitApplyFormSection() {
     position: '',
     resume: null as File | null,
     portfolio: '',
+    source: '',
     message: ''
   })
 
@@ -74,6 +76,7 @@ export default function RecruitApplyFormSection() {
           phone: formData.phone,
           position: formData.position,
           portfolio: formData.portfolio,
+          source: formData.source,
           message: formData.message,
         }),
       })
@@ -90,6 +93,7 @@ export default function RecruitApplyFormSection() {
           position: '',
           resume: null,
           portfolio: '',
+          source: '',
           message: '',
         })
       } else {
@@ -295,6 +299,20 @@ export default function RecruitApplyFormSection() {
                   onChange={handleInputChange}
                   placeholder={typedPlaceholders[3]}
                   className="w-full border-0 border-b border-gray-300 bg-transparent py-3 text-gray-900 placeholder-gray-400 focus:border-gray-600 focus:outline-none focus:ring-0"
+                />
+              </div>
+
+              {/* Source */}
+              <div>
+                <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                  当社の求人を知ったきっかけ
+                </label>
+                <Select
+                  name="source"
+                  value={formData.source}
+                  onChange={(value) => handleSelectChange('source', value)}
+                  options={sourceOptions}
+                  placeholder="選択してください"
                 />
               </div>
 

--- a/src/data/sourceOptions.ts
+++ b/src/data/sourceOptions.ts
@@ -1,0 +1,15 @@
+// お問い合わせ・求人応募フォームで共通利用する「知ったきっかけ」の選択肢
+export const sourceOptions = [
+  { value: 'ビズリーチ', label: 'ビズリーチ' },
+  { value: 'Wantedly', label: 'Wantedly' },
+  { value: 'その他求人サイト', label: 'その他求人サイト' },
+  { value: '社員・知人からの紹介', label: '社員・知人からの紹介' },
+  { value: 'X', label: 'X' },
+  { value: 'LinkedIn', label: 'LinkedIn' },
+  { value: 'note', label: 'note' },
+  { value: '各種メディア掲載記事', label: '各種メディア掲載記事' },
+  { value: '就活イベント・合同説明会・ミートアップ', label: '就活イベント・合同説明会・ミートアップ' },
+  { value: 'アルムナイコミュニティ案内', label: 'アルムナイコミュニティ案内' },
+  { value: 'Google・Yahoo!等の検索エンジン', label: 'Google・Yahoo!等の検索エンジン' },
+  { value: 'その他', label: 'その他' },
+]


### PR DESCRIPTION
## やったこと
お問い合わせフォーム（ContactSection）と求人応募フォーム（RecruitApplyFormSection）の両方に、流入経路を選べる単一選択のセレクトボックスを追加しました。

- 共通選択肢を `src/data/sourceOptions.ts` に切り出し（両フォームで同一の12項目）
  - ビズリーチ / Wantedly / その他求人サイト / 社員・知人からの紹介 / X / LinkedIn / note / 各種メディア掲載記事 / 就活イベント・合同説明会・ミートアップ / アルムナイコミュニティ案内 / Google・Yahoo!等の検索エンジン / その他
- ContactSection: ラベル「当社を知ったきっかけ」のセレクトを追加（任意項目）
- RecruitApplyFormSection: ラベル「当社の求人を知ったきっかけ」のセレクトを追加（任意項目）
- `/api/contact`, `/api/recruit`: 新フィールド `source` を受け取りNotionへ保存（rich_text）
- `/api/contact`: Slack通知にも「知ったきっかけ」を表示

Close #56

## 影響範囲
- `src/data/sourceOptions.ts`（新規）
- `src/components/sections/common/ContactSection.tsx`
- `src/components/sections/recruit/apply/RecruitApplyFormSection.tsx`
- `src/app/api/contact/route.ts`
- `src/app/api/recruit/route.ts`

## 備考
- ⚠️ **デプロイ前にNotion側の対応が必要です。** お問い合わせ用・求人応募用それぞれのデータベースに `source`（テキスト型）プロパティを追加してください。未追加だと `pages.create` がエラーになり、フォーム送信が失敗します。
- `source` は任意項目（未選択でも送信可）。Notion・Slackには未選択時は空欄/「未選択」として記録されます。
- `npx tsc --noEmit` で型チェック通過済み。

## チェックリスト
- [x] 自身のコードをセルフレビューしましたか？
- [x] コーディング規約/フォーマッターに従っていますか？
- [x] 不要な `console.log` やデバッグコードを削除しましたか？