### PR TITLE
feat: お問い合わせフォームにbotスパム対策（ハニーポット＋送信時間チェック）を追加

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -135,9 +135,23 @@ async function sendSlackNotification(data: {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { name, company, subject, email, source, message } = body
+    const { name, company, subject, email, source, message, website, elapsedMs } = body
 
     console.log('Received data:', { name, company, subject, email, source, message })
+
+    // botスパム対策: ハニーポット（人間は入力しない隠しフィールド）に値があれば
+    // 成功を装ってこっそり弾く（Notion保存・Slack通知は行わない）
+    if (website) {
+      console.warn('Honeypot triggered, dropping submission silently')
+      return NextResponse.json({ success: true }, { status: 200 })
+    }
+
+    // botスパム対策: フォーム表示から送信までが短すぎる（3秒未満）場合も弾く
+    const MIN_ELAPSED_MS = 3000
+    if (typeof elapsedMs === 'number' && elapsedMs < MIN_ELAPSED_MS) {
+      console.warn(`Submission too fast (${elapsedMs}ms), dropping submission silently`)
+      return NextResponse.json({ success: true }, { status: 200 })
+    }
 
     // バリデーション
     if (!name || !email || !message) {

--- a/src/components/sections/common/ContactSection.tsx
+++ b/src/components/sections/common/ContactSection.tsx
@@ -16,10 +16,19 @@ export default function ContactSection() {
     subject: '',
     email: '',
     source: '',
-    message: ''
+    message: '',
+    // ハニーポット: 人間は入力しない隠しフィールド（botが埋めると弾く）
+    website: ''
   })
 
   const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // フォーム表示時刻（送信が早すぎる＝botを判定するため）
+  const formLoadedAtRef = useRef<number>(0)
+
+  useEffect(() => {
+    formLoadedAtRef.current = Date.now()
+  }, [])
 
   const titleRef = useRef<HTMLHeadingElement>(null)
   const sectionRef = useRef<HTMLElement>(null)
@@ -54,12 +63,15 @@ export default function ContactSection() {
     setIsSubmitting(true)
 
     try {
+      // フォーム表示からの経過ミリ秒（短すぎる送信はbotとして弾く）
+      const elapsedMs = Date.now() - formLoadedAtRef.current
+
       const response = await fetch('/api/contact', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(formData),
+        body: JSON.stringify({ ...formData, elapsedMs }),
       })
 
       const data = await response.json()
@@ -74,6 +86,7 @@ export default function ContactSection() {
           email: '',
           source: '',
           message: '',
+          website: '',
         })
       } else {
         toast.error(data.error || '送信に失敗しました。もう一度お試しください。')
@@ -214,6 +227,20 @@ export default function ContactSection() {
             <h3 ref={titleRef} className="text-xl md:text-2xl text-gray-600 mb-6 md:mb-8">Say hello</h3>
             
             <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Honeypot: 画面外に隠したbot用トラップ（人間は触れない） */}
+              <div aria-hidden="true" className="absolute left-[-9999px] top-[-9999px] h-0 w-0 overflow-hidden" style={{ pointerEvents: 'none' }}>
+                <label htmlFor="website">Website</label>
+                <input
+                  id="website"
+                  type="text"
+                  name="website"
+                  value={formData.website}
+                  onChange={handleInputChange}
+                  tabIndex={-1}
+                  autoComplete="off"
+                />
+              </div>
+
               {/* Name and Subject Row */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>


### PR DESCRIPTION
## やったこと
お問い合わせフォーム（ContactSection / `/api/contact`）に、botによる自動スパム送信を防ぐ仕組みを追加しました。ユーザーには一切負荷をかけず（CAPTCHAなし）、裏側で弾きます。対象は **contactのみ**（求人応募フォームは対象外）。

- **ハニーポット**: 画面外に隠した入力欄 `website` を追加（人間は見えず触れない／botが自動入力しがち）
  - `type="hidden"` ではなくCSSで画面外配置（hiddenをスキップするbet対策）。`aria-hidden` / `tabIndex={-1}` / `autoComplete="off"` でユーザー・支援技術から隔離
- **送信時間チェック**: フォーム表示時刻を記録し、送信までの経過 `elapsedMs` をAPIへ送信
- **/api/contact**: 次のいずれかに該当したら、Notion保存・Slack通知を行わず `200 success` を返して**こっそり弾く**（botに対策を悟らせない）
  - `website` に値が入っている
  - `elapsedMs < 3000`（表示から3秒未満の送信）

Close #58

## 影響範囲
- `src/components/sections/common/ContactSection.tsx`
- `src/app/api/contact/route.ts`

## 備考
- 正常な送信は従来どおりNotion保存＋Slack通知される（挙動変更なし）。
- silent dropは検知用に `console.warn` を出力（サーバーログでスパム件数を把握できる）。
- `elapsedMs` は型が `number` のときのみ判定するため、万一未送信でも正常送信は弾かれない安全側設計。
- `npx tsc --noEmit` 通過済み。
- 既存の `'i' is declared but never read`（タイトル文字分割部）は本PR対象外の既存コード。

## チェックリスト
- [x] 自身のコードをセルフレビューしましたか？
- [x] コーディング規約/フォーマッターに従っていますか？
- [x] 不要な `console.log` やデバッグコードを削除しましたか？