### PR TITLE
feat: Tech Blog への導線を追加（フッター＋CTAバンド）

### DIFF
--- a/messages/en/core.json
+++ b/messages/en/core.json
@@ -106,5 +106,11 @@
     "alumni": "Alumni community invitation",
     "searchEngine": "Search engine (Google, Yahoo!, etc.)",
     "other": "Other"
+  },
+  "techBlogCta": {
+    "eyebrow": "Tech Blog",
+    "heading": "See how we build.",
+    "body": "Our engineers share the decisions behind our tech choices, hands-on product-development insights, and our engineering culture.",
+    "cta": "Read the Tech Blog"
   }
 }

--- a/messages/ja/core.json
+++ b/messages/ja/core.json
@@ -106,5 +106,11 @@
     "alumni": "アルムナイコミュニティ案内",
     "searchEngine": "Google・Yahoo!等の検索エンジン",
     "other": "その他"
+  },
+  "techBlogCta": {
+    "eyebrow": "Tech Blog",
+    "heading": "開発の裏側を、のぞいてみる。",
+    "body": "技術選定の意思決定やプロダクト開発で得た知見、開発カルチャーを、エンジニア自身が発信しています。",
+    "cta": "Read the Tech Blog"
   }
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,6 +8,7 @@ import ContactSection from "@/components/sections/common/ContactSection"
 import JoinUsSection from "@/components/sections/common/JoinUsSection"
 import MissionSection from "@/components/sections/home/MissionSection"
 import NewsSection from "@/components/sections/home/NewsSection"
+import TechBlogCta from "@/components/sections/common/TechBlogCta"
 
 interface HomeProps {
   params: Promise<{ locale: string }>
@@ -27,6 +28,7 @@ export default async function Home({ params }: HomeProps) {
       </div>
       <ServiceDetailSection />
       <NewsSection locale={locale} />
+      <TechBlogCta locale={locale} />
       <JoinUsSection />
       <ContactSection />
       <Footer />

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,12 +1,13 @@
 import TransitionLink from '@/components/ui/TransitionLink'
 import { useTranslations } from 'next-intl'
-import { companySNS } from '@/data/company'
+import { companySNS, techBlogUrl } from '@/data/company'
 
 const COMPANY_LINKS = [
   { name: 'About', href: '/about' },
   { name: 'Service', href: '/service' },
   { name: 'Member', href: '/member' },
   { name: 'News', href: '/news' },
+  { name: 'Tech Blog', href: techBlogUrl, external: true },
   { name: 'Contact', href: '/contact' },
 ]
 
@@ -110,12 +111,24 @@ export default function Footer() {
             <ul className="space-y-3">
               {COMPANY_LINKS.map((link) => (
                 <li key={link.name}>
-                  <TransitionLink
-                    href={link.href}
-                    className="text-base text-gray-300 hover:text-white transition-colors"
-                  >
-                    {link.name}
-                  </TransitionLink>
+                  {link.external ? (
+                    <a
+                      href={link.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group inline-flex items-center gap-1.5 text-base text-gray-300 hover:text-white transition-colors"
+                    >
+                      {link.name}
+                      <ExternalIcon />
+                    </a>
+                  ) : (
+                    <TransitionLink
+                      href={link.href}
+                      className="text-base text-gray-300 hover:text-white transition-colors"
+                    >
+                      {link.name}
+                    </TransitionLink>
+                  )}
                 </li>
               ))}
             </ul>

--- a/src/components/sections/common/TechBlogCta.tsx
+++ b/src/components/sections/common/TechBlogCta.tsx
@@ -1,0 +1,63 @@
+import { getTranslations } from 'next-intl/server'
+import { techBlogUrl } from '@/data/company'
+
+interface TechBlogCtaProps {
+  locale: string
+}
+
+/**
+ * Tech Blog（tech.starup01.jp）への導線となる共通CTAバンド。
+ * 黒背景の全幅バンド。複数ページで再利用する。
+ */
+export default async function TechBlogCta({ locale }: TechBlogCtaProps) {
+  const t = await getTranslations({ locale, namespace: 'techBlogCta' })
+
+  return (
+    <section className="py-10 md:py-14" data-bg="light">
+      <div className="max-w-[1500px] mx-auto px-4 md:px-8">
+        <a
+          href={techBlogUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group block bg-black text-white overflow-hidden"
+        >
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between p-6 md:p-8 lg:p-10">
+            {/* Left: copy */}
+            <div className="md:max-w-2xl">
+              <p className="text-[10px] uppercase tracking-[0.3em] text-gray-500 mb-2">
+                {t('eyebrow')}
+              </p>
+              <h2 className="text-xl md:text-2xl lg:text-3xl font-medium leading-tight tracking-tight">
+                {t('heading')}
+              </h2>
+              <p className="mt-3 text-sm md:text-base text-gray-400">
+                {t('body')}
+              </p>
+            </div>
+
+            {/* Right: button */}
+            <div className="shrink-0">
+              <span className="inline-flex items-center gap-2.5 border border-white/25 px-6 py-3 md:px-7 md:py-3.5 text-sm md:text-base font-medium group-hover:bg-white group-hover:text-black transition-colors">
+                {t('cta')}
+                <svg
+                  className="w-4 h-4 transition-transform group-hover:translate-x-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M17 8l4 4m0 0l-4 4m4-4H3"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/src/components/sections/news/NewsListSection.tsx
+++ b/src/components/sections/news/NewsListSection.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from 'next-intl/server'
 import { getAllNewsForList } from '@/lib/news'
 import TransitionLink from '@/components/ui/TransitionLink'
 import ExploreLinks from '@/components/sections/news/ExploreLinks'
+import TechBlogCta from '@/components/sections/common/TechBlogCta'
 
 export default async function NewsListSection({ locale }: { locale: string }) {
   const t = await getTranslations({ locale, namespace: 'sections.news.list' })
@@ -100,6 +101,7 @@ export default async function NewsListSection({ locale }: { locale: string }) {
         </div>
       </div>
     </section>
+    <TechBlogCta locale={locale} />
     <ExploreLinks locale={locale} />
     </>
   )

--- a/src/components/sections/recruit/culture/CultureSection.tsx
+++ b/src/components/sections/recruit/culture/CultureSection.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from 'next-intl/server'
 import TransitionLink from '@/components/ui/TransitionLink'
 import { getCulture } from '@/data/culture'
+import TechBlogCta from '@/components/sections/common/TechBlogCta'
 
 interface CultureSectionProps {
   locale: string
@@ -141,6 +142,9 @@ export default async function CultureSection({ locale }: CultureSectionProps) {
           </div>
         </div>
       </section>
+
+      {/* ━━━ Tech Blog CTA ━━━ */}
+      <TechBlogCta locale={locale} />
     </div>
   )
 }

--- a/src/data/company.ts
+++ b/src/data/company.ts
@@ -12,6 +12,9 @@ export const companySNS: CompanySNS = {
   linkedin: "https://www.linkedin.com/company/%E6%A0%AA%E5%BC%8F%E4%BC%9A%E7%A4%BEstar-up/",
 }
 
+/** エンジニアチームによる技術ブログ（別サブドメインの外部サイト） */
+export const techBlogUrl = "https://tech.starup01.jp/"
+
 /**
  * 会社概要（About ページの Information セクション）
  * value は行配列。描画側で改行（<br/>）として展開する。


### PR DESCRIPTION
## 概要
エンジニアチームの技術ブログ [STARUP Tech Blog](https://tech.starup01.jp/) をHPから導線として追加します。

## 変更内容
- **フッター**: Company列に「Tech Blog」外部リンクを追加
- **CTAバンド**（黒背景の共通コンポーネント `TechBlogCta`）を以下に配置
  - トップ (`/`) … News セクション直後
  - News (`/news`) … 記事一覧の後・「次に見る」の前
  - Culture (`/recruit/culture`) … 下部CTAカードの後
- 文言は `core.json` の `techBlogCta` で ja/en 対応
- Tech Blog の URL は `src/data/company.ts` の `techBlogUrl` に集約

## 確認
- `tsc --noEmit` 通過 / `eslint` 通過
- ローカル（dev）でトップ・News・Culture の3ページに表示・外部リンク（別タブ）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)