### PR TITLE
feat: Recruit/News 一覧に手動並び順（Order）を追加

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: deploy
+description: starup-hp を Vercel 本番へデプロイする。GitHub 自動デプロイが切れている間の手動デプロイフロー。「デプロイして」「本番に出して」「本番反映して」「vercel prod」等で発火。
+allowed-tools: Bash(vercel *), Bash(npm i -g vercel), Bash(git checkout *), Bash(git pull *), Bash(git status *), Bash(git log *), Bash(git branch *), Bash(gh api *)
+---
+
+現在の `main` を Vercel の本番（`https://www.starup01.jp`）へ手動デプロイする。
+
+## なぜ手動か
+
+リポジトリを個人（`ShotaGhoona`）から Org（`starup-ai-pj`）へ移管した際に、Vercel の GitHub App 連携が切れ、push での自動デプロイがトリガーされなくなっている。復旧するまでは CLI から手動デプロイする（連携は GitHub 側で Vercel App に `starup-ai-pj/starup-hp` へのアクセスを承認 → `vercel git connect` で復旧できる）。
+
+## 前提情報
+
+- Vercel プロジェクト: `starup-hp`
+- スコープ（チーム）: `shota-yamashitas-projects-c5da0fce`
+- 本番エイリアス: `https://www.starup01.jp`
+- `.vercel` は gitignore 済み。`vercel link` 時に `.env.local` へ `VERCEL_OIDC_TOKEN` が追記されることがある（コミット不要）。
+
+## 引数
+
+`$ARGUMENTS` は任意。省略時は現在の `main` をそのまま本番デプロイする。`preview` が渡された場合はプレビューデプロイ（`--prod` を付けない）。
+
+## 手順
+
+1. **CLI とログインの確認**
+   ```
+   vercel --version || npm i -g vercel
+   vercel whoami
+   ```
+   - 未ログインなら、ユーザーに `! vercel login`（プロンプトに直接入力）を依頼する。対話ログインはこちらでは実行できない。
+   - `command not found` 等で PATH が崩れている場合は
+     `export PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"` を前置する。
+
+2. **プロジェクトのリンク確認**（`.vercel/project.json` が無ければ）
+   ```
+   vercel link --yes --project starup-hp --scope shota-yamashitas-projects-c5da0fce
+   ```
+
+3. **main を最新化**（別ブランチにいる/未マージがある場合）
+   ```
+   git checkout main
+   git pull --ff-only
+   git log --oneline -3
+   ```
+   - デプロイ対象コミットをユーザーに一言示す。
+
+4. **本番デプロイ**
+   ```
+   vercel --prod --yes
+   ```
+   - `preview` 指定時は `vercel --yes`（`--prod` なし）。
+   - 出力の `readyState: READY` と Production URL を確認。
+
+5. **完了報告**
+   - 本番URL（`https://www.starup01.jp`）と、反映したコミット（`git log` の先頭）を簡潔に報告。
+   - 数分で反映される旨を添える。
+
+## 注意
+
+- ビルドは Vercel 側で走る。`readyState` が `READY` 以外（`ERROR` 等）ならログ URL（`inspectorUrl`）を提示し、原因を確認する。
+- 未コミットのローカル変更は `vercel --prod` の対象になる（CLI はワークツリーをアップロードする）。意図しない差分が無いか `git status` を先に確認する。
+- 自動デプロイが復旧済み（`vercel git connect` 成功）の場合は、この手動フローは不要。main への push/マージで自動デプロイされる。

--- a/src/lib/news/index.ts
+++ b/src/lib/news/index.ts
@@ -6,6 +6,7 @@
 
 import { requireEnv } from '@/lib/notion/client'
 import { createContentRepository } from '@/lib/notion/repository'
+import { byManualOrder } from '@/lib/notion/ordering'
 import {
   getUniqueId,
   getTitle,
@@ -42,6 +43,10 @@ const repository = createContentRepository<NewsListItem, NewsPost>(
       blocks,
       thumbnail: getFileUrl(page, 'Thumbnail') || DEFAULT_IMAGE,
     }),
+  },
+  {
+    // 手動並び順（Order 昇順）を優先。未設定は Date 降順のまま最後尾へ。
+    orderListItems: byManualOrder('Order'),
   }
 )
 

--- a/src/lib/notion/fields.ts
+++ b/src/lib/notion/fields.ts
@@ -60,6 +60,12 @@ export function getDate(page: NotionPage, property: string): string {
   return page.properties[property]?.date?.start || ''
 }
 
+/** number プロパティ → 数値（未設定 / プロパティ未追加は null） */
+export function getNumber(page: NotionPage, property: string): number | null {
+  const value = page.properties[property]?.number
+  return typeof value === 'number' ? value : null
+}
+
 /** files プロパティ → 先頭ファイルのURL（file / external 両対応） */
 export function getFileUrl(page: NotionPage, property: string): string {
   const files = page.properties[property]?.files

--- a/src/lib/notion/ordering.ts
+++ b/src/lib/notion/ordering.ts
@@ -1,0 +1,25 @@
+/**
+ * 一覧の並べ替えヘルパー
+ * Notion の sorts 取得後に、アプリ側で安定ソートを上乗せするための汎用関数。
+ * プロパティ名は呼び出し側（各ドメイン）が渡すため、DB構造の知識はここに持たせない。
+ */
+
+import { NotionPage } from './types'
+import { getNumber } from './fields'
+
+/**
+ * 手動並び順（number プロパティ）で昇順に並べ替える。
+ * - 値が小さいものほど上に来る。
+ * - 未設定 / プロパティ未追加のレコードは最後尾に回す（= まだ番号を振っていないものは下）。
+ * - Array.prototype.sort は安定ソートのため、番号が同値・未設定同士の並びは
+ *   Notion の sorts（Date 降順）の結果がそのまま維持される。
+ *   → 「Order 優先、未設定は Date 降順」を、Order プロパティが無くても壊さず実現する。
+ */
+export function byManualOrder(property: string) {
+  return (pages: NotionPage[]): NotionPage[] =>
+    [...pages].sort((a, b) => {
+      const va = getNumber(a, property) ?? Number.POSITIVE_INFINITY
+      const vb = getNumber(b, property) ?? Number.POSITIVE_INFINITY
+      return va - vb
+    })
+}

--- a/src/lib/notion/repository.ts
+++ b/src/lib/notion/repository.ts
@@ -25,6 +25,12 @@ interface RepositoryOptions {
    * データセット全体を見た判定ができる。未指定なら全件公開。
    */
   filterVisible?: (pages: NotionPage[]) => NotionPage[]
+  /**
+   * 一覧の並べ替え（Notion の sorts 取得後にアプリ側で適用）。
+   * 手動並び順など、プロパティ未追加でも壊れない後方互換な並べ替えをドメイン側に閉じる。
+   * 安定ソート前提で、sorts の結果を二次キーとして活かす想定。未指定なら sorts のまま。
+   */
+  orderListItems?: (pages: NotionPage[]) => NotionPage[]
 }
 
 export function createContentRepository<TListItem, TPost>(
@@ -34,11 +40,12 @@ export function createContentRepository<TListItem, TPost>(
   options?: RepositoryOptions
 ) {
   const filterVisible = options?.filterVisible ?? ((pages) => pages)
+  const orderListItems = options?.orderListItems ?? ((pages) => pages)
 
-  /** 一覧を取得（sorts・公開フィルタ適用済み） */
+  /** 一覧を取得（sorts・公開フィルタ・並べ替え適用済み） */
   async function getAllForList(): Promise<TListItem[]> {
     const pages = await queryDatabase(databaseId, { sorts })
-    return filterVisible(pages).map(mappers.toListItem)
+    return orderListItems(filterVisible(pages)).map(mappers.toListItem)
   }
 
   /** unique_id で詳細を取得（非公開・見つからなければ null） */

--- a/src/lib/recruit/index.ts
+++ b/src/lib/recruit/index.ts
@@ -6,6 +6,7 @@
 
 import { requireEnv } from '@/lib/notion/client'
 import { createContentRepository } from '@/lib/notion/repository'
+import { byManualOrder } from '@/lib/notion/ordering'
 import { NotionPage } from '@/lib/notion/types'
 import {
   getUniqueId,
@@ -76,7 +77,11 @@ const repository = createContentRepository<RecruitListItem, RecruitPost>(
       blocks,
     }),
   },
-  { filterVisible: filterPublished }
+  {
+    filterVisible: filterPublished,
+    // 手動並び順（Order 昇順）を優先。未設定は Date 降順のまま最後尾へ。
+    orderListItems: byManualOrder('Order'),
+  }
 )
 
 /** 採用情報一覧を取得（日付降順） */


### PR DESCRIPTION
## 概要
Recruit / News の一覧表示に、Notion 上で手動指定できる並び順（`Order`）を導入する。あわせて `deploy` スキルを追加。

## 変更内容
- `getNumber` フィールドヘルパを追加（未設定/プロパティ未追加は `null`）
- `byManualOrder('Order')` ヘルパ（安定ソート）で sorts 取得後にアプリ側で並べ替え
- repository に `orderListItems` オプションを追加
- Recruit / News 両方に適用
- `deploy` スキルを追加

## 並び順の仕様
- **Order（数値）昇順** … 小さい番号が上
- **Order 未設定** … 従来通り **Date 降順**で、番号付きの下に並ぶ
- Notion の sorts（Date 降順）を安定ソートで上書きするため、同値/未設定同士は日付の新しい順を維持

## Notion 側の運用
- Recruit DB / News DB に **Number 型の `Order`** プロパティを追加
- 上に固定したいものから `10, 20, 30…` と入力（間隔を空けると挿入しやすい）
- プロパティが無くても壊れない（その場合は全件 Date 降順のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)